### PR TITLE
Update styles to look like GitHub source codes

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -75,7 +75,7 @@ const inspectPage = () => {
 
   style.innerHTML =
       '.gp-code-jumper-targeted { position: relative; display: inline-block }'
-    + '.gp-code-jumper-targeted__popup { position: absolute; left: calc(-50% - 40px); box-shadow: 0 0 3px #888888; color: #000000; border: 1px solid #888888; background-color: #FFFFFF; display: none; z-index: 1; padding: 10px; border-radius: 2px; }'
+    + '.gp-code-jumper-targeted__popup { position: absolute; left: calc(-50% - 40px); box-shadow: 0 0 3px #888888; color: #000000; border: 1px solid #888888; background-color: #FFFFFF; display: none; z-index: 1; padding: 10px; border-radius: 2px; font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; font-size: 12px }'
     + '.gp-code-jumper-targeted:hover .gp-code-jumper-targeted__popup { display: block }'
     + '.gp-code-jumper-colors--primary { color: #F92772 }'
     + '.gp-code-jumper-colors--secondary { color: #74715E }'


### PR DESCRIPTION
The fonts are exactly the same as GitHub defaults.
<img src="https://user-images.githubusercontent.com/6535425/63357483-78306080-c3a4-11e9-9400-09bfa7055dd4.png" width="599">
