### PR TITLE
Fix a bug where the variable node is inside of a variable

### DIFF
--- a/services/kernel.js
+++ b/services/kernel.js
@@ -25,6 +25,16 @@ const getSPLWithElements = (matches, marker) => {
   return items;
 };
 
+const getLineNumberFromNode = (node) => {
+  let current = node;
+  while (current = current.parentNode) {
+    const id = current.getAttribute('id');
+    if (/^LC/.test(id)) {
+      return id.replace(/^LC/, '') * 1;
+    }
+  }
+};
+
 const getVariableWithElements = (matches, marker) => {
   const items = [];
   matches.forEach((value, key) => {
@@ -48,7 +58,7 @@ const getVariableWithElements = (matches, marker) => {
           return;
         }
 
-        const lineNumber = value.parentNode.parentNode.getAttribute('id').replace(/^LC/, '') * 1;
+        const lineNumber = getLineNumberFromNode(value);
 
         let beforeDiff = null;
         let targetedLineNumber = null;
@@ -205,7 +215,7 @@ const getDynamicMethodConstructionNode = (matches, marker) => {
           }
 
           // Find line number
-          const lineNumber = value.parentNode.parentNode.getAttribute('id').replace(/^LC/, '') * 1;
+          const lineNumber = getLineNumberFromNode(value);
           methodPaths[lineNumber] = classes[char][loweredClassName];
           break;
         }

--- a/tests/test.php
+++ b/tests/test.php
@@ -25,6 +25,7 @@ class A extends \Exception implements ArrayAccess
 
     // Normal
     var_dump('test');
+    var_dump("$message");
     var_dump(\Exception::class);
     var_dump(ReflectionClass::export($this));
     var_dump(microtime(true));


### PR DESCRIPTION
The variable node can be nested inside of a variable but the current implementation simply expects its direct ancestor points to a line node, which is not always true.

Reproducible in:
https://github.com/laravel/framework/blob/08f8ef951e3f54e43bb9829c47393e9975b0a9ff/src/Illuminate/Container/Container.php#L989-L994